### PR TITLE
Fix keymap & fix doc typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Below is an example using vim's `complete-items`
 func! Demo()
   let l:items = [
     \ { 'word': 'First', 'abbr': '1st', 'user_data': 'Custom data 1' },
-    \ { 'word': 'Second', 'abbr': '2nd', 'user_data': 'Custom data 2' }
+    \ { 'word': 'Second', 'abbr': '2nd', 'user_data': 'Custom data 2' },
     \ { 'word': 'Third', 'abbr': '3rd', 'user_data': 'Custom data 3' }
     \ ]
 

--- a/ftplugin/actionmenu.vim
+++ b/ftplugin/actionmenu.vim
@@ -48,6 +48,7 @@ endfunction
 
 " Mappings
 mapclear <buffer>
+imapclear <buffer>
 inoremap <buffer> <expr> <CR> actionmenu#select_item()
 imap <buffer> <C-y> <CR>
 imap <buffer> <C-e> <esc>


### PR DESCRIPTION
I have set this keymap in my vimrc
```vim
inoremap jj <Esc>
inoremap jk <Esc>
```
but this line of code seems not to remove that keymap. 
https://github.com/kizza/actionmenu.nvim/blob/b74782cf59c009a37067f5e22c8e9f8cc8a255d6/ftplugin/actionmenu.vim#L50

So `<nowait>` might be necessary.