### PR TITLE
Fixes delay if floating window is visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Once both `actionmenu.nvim` and `coc.nvim` are installed, put the folowing in yo
 let s:code_actions = []
 
 func! ActionMenuCodeActions() abort
+  if coc#util#has_float()
+    call coc#util#float_hide()
+  endif
+
   let s:code_actions = CocAction('codeActions')
   let l:menu_items = map(copy(s:code_actions), { index, item -> item['title'] })
   call actionmenu#open(l:menu_items, 'ActionMenuCodeActionsCallback')


### PR DESCRIPTION
I noticed if I navigated to a line with some code actions (eg. eslint warning) and called `ActionMenuCodeActions()` there was a noticeable delay before opening the actionmenu because a floating window was already visible.

For reference (line number may change, search for `show_code_action_menu`)
https://github.com/Gee19/dotfiles/blob/master/vimrc#L300-L329

Anyway, thanks for the awesome plugin!

