### PR TITLE
Fixed command to close floating window.

### DIFF
--- a/autoload/actionmenu.vim
+++ b/autoload/actionmenu.vim
@@ -86,7 +86,7 @@ endfunction
 
 function! actionmenu#close()
   if g:actionmenu#win
-    call feedkeys("\<C-w>\<C-c>")
+    quit
     let g:actionmenu#win = 0
   endif
 endfunction


### PR DESCRIPTION
'\<C-w>\<C-c>' does not close the active window, as stated in the docs ':help close'. I used 'quit' to fix it.