### PR TITLE
Fix hide float example deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Once both `actionmenu.nvim` and `coc.nvim` are installed, put the folowing in yo
 let s:code_actions = []
 
 func! ActionMenuCodeActions() abort
-  if coc#util#has_float()
-    call coc#util#float_hide()
+  if coc#float#has_float()
+    call coc#float#close_all()
   endif
 
   let s:code_actions = CocAction('codeActions')


### PR DESCRIPTION
[coc.nvim deprecated](https://github.com/neoclide/coc.nvim/commit/498964f05f7eee287cd1115cbabbdc86303c00ab) the method in the [example](https://github.com/kizza/actionmenu.nvim/commit/bc119ba56ea2b9bac37558f0945d56beff8be0ae) I contributed before, figured I would fix it.